### PR TITLE
Fixed variable name for database connection

### DIFF
--- a/docs/source/v2/application-testing.blade.md
+++ b/docs/source/v2/application-testing.blade.md
@@ -149,7 +149,7 @@ abstract class TestCase extends BaseTestCase
 
 phpunit.xml:
 ```xml
-<server name="DB_DRIVER" value="sqlite"/>
+<server name="DB_CONNECTION" value="sqlite"/>
 <server name="DB_DATABASE" value="database/testing.sqlite"/>
 ```
 


### PR DESCRIPTION
I think this should be DB_CONNECTION instead of DB_DRIVER?