### PR TITLE
Provide exempt_domains examples

### DIFF
--- a/docs/source/v2/central-app.blade.md
+++ b/docs/source/v2/central-app.blade.md
@@ -15,7 +15,7 @@ Routes in the `routes/web.php` file are the central routes. When they are visite
 
 ## Central domains {#central-domains}
 
-However, since you don't want routes related to the app on your main domain and sign up forms on tenant domains, you must also define what domains host the central stuff in the `tenancy.exempt_domains` config.
+However, since you don't want routes related to the app on your main domain and sign up forms on tenant domains, you must also define what domains host the central stuff in the `tenancy.exempt_domains` config. The exempt domains should not include the protocol. For example, you should include ```example.com``` rather than ```https://example.com```, otherwise this will throw a ```TenantCouldNotBeIdentifiedException``` exception.
 
 ## Using central things inside the tenant app {#using-central-things-inside-the-tenant-app}
 

--- a/docs/source/v2/central-app.blade.md
+++ b/docs/source/v2/central-app.blade.md
@@ -17,7 +17,7 @@ Routes in the `routes/web.php` file are the central routes. When they are visite
 
 However, since you don't want routes related to the app on your main domain and sign up forms on tenant domains, you must also define what domains host the central stuff in the `tenancy.exempt_domains` config.
 
-The exempt domains should not include the protocol. For example, you should include ```example.com``` rather than ```https://example.com```, otherwise this will throw a ```TenantCouldNotBeIdentifiedException``` exception.
+The exempt domains should not include the protocol. For example, you should include ```example.com``` rather than ```https://example.com```.
 
 ## Using central things inside the tenant app {#using-central-things-inside-the-tenant-app}
 

--- a/docs/source/v2/central-app.blade.md
+++ b/docs/source/v2/central-app.blade.md
@@ -15,7 +15,9 @@ Routes in the `routes/web.php` file are the central routes. When they are visite
 
 ## Central domains {#central-domains}
 
-However, since you don't want routes related to the app on your main domain and sign up forms on tenant domains, you must also define what domains host the central stuff in the `tenancy.exempt_domains` config. The exempt domains should not include the protocol. For example, you should include ```example.com``` rather than ```https://example.com```, otherwise this will throw a ```TenantCouldNotBeIdentifiedException``` exception.
+However, since you don't want routes related to the app on your main domain and sign up forms on tenant domains, you must also define what domains host the central stuff in the `tenancy.exempt_domains` config.
+
+The exempt domains should not include the protocol. For example, you should include ```example.com``` rather than ```https://example.com```, otherwise this will throw a ```TenantCouldNotBeIdentifiedException``` exception.
 
 ## Using central things inside the tenant app {#using-central-things-inside-the-tenant-app}
 

--- a/docs/source/v2/central-app.blade.md
+++ b/docs/source/v2/central-app.blade.md
@@ -17,7 +17,7 @@ Routes in the `routes/web.php` file are the central routes. When they are visite
 
 However, since you don't want routes related to the app on your main domain and sign up forms on tenant domains, you must also define what domains host the central stuff in the `tenancy.exempt_domains` config.
 
-The exempt domains should not include the protocol. For example, you should include ```example.com``` rather than ```https://example.com```.
+The exempt domains should not include the protocol. For example, you should include `example.com` rather than `https://example.com`.
 
 ## Using central things inside the tenant app {#using-central-things-inside-the-tenant-app}
 

--- a/docs/source/v2/configuration.blade.md
+++ b/docs/source/v2/configuration.blade.md
@@ -38,7 +38,7 @@ Controller namespace used for routes in `routes/tenant.php`. The default value i
 
 ### `exempt_domains` {#exempt-domains}
 
-If a hostname from this array is visited, the `tenant.php` routes won't be registered, letting you use the same routes as in that file. This should be the root domain without the protocol (i.e., ```example.com``` rather than ```https://example.com```).
+If a hostname from this array is visited, the `tenant.php` routes won't be registered, letting you use the same routes as in that file. This should be the domain without the protocol (i.e., ```example.com``` rather than ```https://example.com```).
 
 ### `database` {#database}
 

--- a/docs/source/v2/configuration.blade.md
+++ b/docs/source/v2/configuration.blade.md
@@ -38,7 +38,7 @@ Controller namespace used for routes in `routes/tenant.php`. The default value i
 
 ### `exempt_domains` {#exempt-domains}
 
-If a hostname from this array is visited, the `tenant.php` routes won't be registered, letting you use the same routes as in that file. This should be the domain without the protocol (i.e., ```example.com``` rather than ```https://example.com```).
+If a hostname from this array is visited, the `tenant.php` routes won't be registered, letting you use the same routes as in that file. This should be the domain without the protocol (i.e., `example.com` rather than `https://example.com`).
 
 ### `database` {#database}
 

--- a/docs/source/v2/configuration.blade.md
+++ b/docs/source/v2/configuration.blade.md
@@ -38,7 +38,7 @@ Controller namespace used for routes in `routes/tenant.php`. The default value i
 
 ### `exempt_domains` {#exempt-domains}
 
-If a hostname from this array is visited, the `tenant.php` routes won't be registered, letting you use the same routes as in that file.
+If a hostname from this array is visited, the `tenant.php` routes won't be registered, letting you use the same routes as in that file. This should be the root domain without the protocol (i.e., ```example.com``` rather than ```https://example.com```).
 
 ### `database` {#database}
 


### PR DESCRIPTION
I hit a small snag when installing this package when I included the protocol for my central app exempt domains. After some tinkering, I realized that it just required the base domain. I've added some examples to the docs to help clarify for new users of the package so they aren't presented with an Exception.