### PR TITLE
Fix Typo

### DIFF
--- a/source/docs/v3/tenant-identification.blade.md
+++ b/source/docs/v3/tenant-identification.blade.md
@@ -40,7 +40,7 @@ The middleware for this method is `Stancl\Tenancy\Middleware\InitializeTenancyBy
 
 If you'd like to use subdomains and domains at the same time, use the `Stancl\Tenancy\Middleware\InitializeTenancyByDomainOrSubdomain` middleware.
 
-Records that contain **dots** in the `domain` column will be treated as subdomains (hostnames) and records that don't contain any dots will be treated as domains.
+Records that contain **dots** in the `domain` column will be treated as subdomains and records that don't contain any dots will be treated as domains (hostnames).
 
 ## Path identification
 

--- a/source/docs/v3/tenant-identification.blade.md
+++ b/source/docs/v3/tenant-identification.blade.md
@@ -40,7 +40,7 @@ The middleware for this method is `Stancl\Tenancy\Middleware\InitializeTenancyBy
 
 If you'd like to use subdomains and domains at the same time, use the `Stancl\Tenancy\Middleware\InitializeTenancyByDomainOrSubdomain` middleware.
 
-Records that contain **dots** in the `domain` column will be treated as domains (hostnames) and records that don't contain any dots will be treated as subdomains.
+Records that contain **dots** in the `domain` column will be treated as subdomains (hostnames) and records that don't contain any dots will be treated as domains.
 
 ## Path identification
 


### PR DESCRIPTION
The statement "Records that contain dots in the domain column will be treated as domains (hostnames) and records that don't contain any dots will be treated as subdomains" should be the other way round