### PR TITLE
Subdomain/ Domain Clarification in Tenant Identification Docs

### DIFF
--- a/source/docs/v3/tenant-identification.blade.md
+++ b/source/docs/v3/tenant-identification.blade.md
@@ -40,7 +40,7 @@ The middleware for this method is `Stancl\Tenancy\Middleware\InitializeTenancyBy
 
 If you'd like to use subdomains and domains at the same time, use the `Stancl\Tenancy\Middleware\InitializeTenancyByDomainOrSubdomain` middleware.
 
-Records that contain **dots** in the `domain` column will be treated as subdomains and records that don't contain any dots will be treated as domains (hostnames).
+Records that contain **dots** in the `domain` column will be treated as domains/hostnames (eg. `foo.bar.com`) and records that don't contain any dots will be treated as subdomains (eg. `foo`).
 
 ## Path identification
 


### PR DESCRIPTION
I believe this paragraph has the information switched. A string in the `domain` column that contains a **dot** would represent a domain/hostname and a string in this column without a dot, would represent a subdomain. The current documentation has this flipped. 

It had me second guessing myself. Unless I am misunderstanding something.

Maybe I am misunderstanding things, and if so, then disregard this PR.