### PR TITLE
Improved Horizon documentation regarding tags

### DIFF
--- a/source/docs/v3/integrations/horizon.blade.md
+++ b/source/docs/v3/integrations/horizon.blade.md
@@ -8,13 +8,20 @@ section: content
 
 Make sure your [queues]({{ $page->link('queues') }}) are configured correctly before using this.
 
-You may add the current tenant's id to your job tags:
+## Tags
+
+You may add the current tenant's id to your job tags by defining a `tags` method on the class:
 
 ```php
+/**
+* Get the tags that should be assigned to the job.
+*
+* @return array
+*/
 public function tags()
 {
     return [
-        'tenant' => tenant('id'),
+        'tenant:' . tenant('id'),
     ];
 }
 ```


### PR DESCRIPTION
- Fixed the snippet for passing tags to the job
- Wrapped content in a Tags header to prepare for more content in the
future
- Added comment to the tags method to mimic Laravel's documentation
- Made it slightly more clear that the tags method should be applied to
the actual job class