### PR TITLE
Add example to use "tenant_route()" helper.

### DIFF
--- a/source/docs/v3/features/cross-domain-redirect.blade.md
+++ b/source/docs/v3/features/cross-domain-redirect.blade.md
@@ -13,3 +13,9 @@ Sometimes you may want to redirect the user to a specific route on a different d
 ```php
 return redirect()->route('home')->domain($domain);
 ```
+
+You can also use the `tenant_route()` helper to redirect users between domains. Which also works when redirecting the user from the central domain to the tenant domain.
+
+```php
+return redirect(tenant_route($domain, 'home'));
+```

--- a/source/docs/v3/features/cross-domain-redirect.blade.md
+++ b/source/docs/v3/features/cross-domain-redirect.blade.md
@@ -14,7 +14,7 @@ Sometimes you may want to redirect the user to a specific route on a different d
 return redirect()->route('home')->domain($domain);
 ```
 
-You can also use the `tenant_route()` helper to redirect users between domains. Which also works when redirecting the user from the central domain to the tenant domain.
+You can also use the `tenant_route()` helper to redirect users to another domain.
 
 ```php
 return redirect(tenant_route($domain, 'home'));


### PR DESCRIPTION
Added a little example to use `tenant_route()` helper. Can be useful when redirecting users from the central domain to the tenant domain.