### PR TITLE
Update tenant-migrations.blade.md

### DIFF
--- a/source/docs/v2/tenant-migrations.blade.md
+++ b/source/docs/v2/tenant-migrations.blade.md
@@ -23,7 +23,7 @@ You can run migrations from outside the command line as well. To run migrations 
 $tenant = \Tenant::create('tenant1.localhost');
 
 \Artisan::call('tenants:migrate', [
-    '--tenants' => [$tenant->id];
+    '--tenants' => [$tenant->id]
 ]);
 ```
 


### PR DESCRIPTION
semicolon wrongly placed in example's array element producing syntax error if copied and used