### PR TITLE
update information on queues

### DIFF
--- a/source/docs/v3/queues.blade.md
+++ b/source/docs/v3/queues.blade.md
@@ -26,7 +26,7 @@ To force the database queue driver to use the central connection, open your `que
 
 Make sure the connection used by the queue is not in `tenancy.redis.prefixed_connections`.
 
->If you are making use of a different `REDIS_CLIENT ` other than `phpredis` (which is the default on most Laravel apps), you may run into an error indicating that Laravel `tried to set a connection on null` in the RedisManager class. Defaulting back to `phpredis` as the `REDIS_CLIENT` should fix this issue.
+>If you are making use of a different `REDIS_CLIENT ` other than `phpredis` (which is the default on most Laravel apps) or `predis`, you may run into an error indicating that Laravel `tried to set a connection on null` in the RedisManager class. Defaulting back to `phpredis` as the `REDIS_CLIENT` should fix this issue.
 
 ## Central queues {#central-queues}
 

--- a/source/docs/v3/queues.blade.md
+++ b/source/docs/v3/queues.blade.md
@@ -26,6 +26,8 @@ To force the database queue driver to use the central connection, open your `que
 
 Make sure the connection used by the queue is not in `tenancy.redis.prefixed_connections`.
 
+>If you are making use of a different `REDIS_CLIENT ` other than `phpredis` (which is the default on most Laravel apps), you may run into an error indicating that Laravel `tried to set a connection on null` in the RedisManager class. Defaulting back to `phpredis` as the `REDIS_CLIENT` should fix this issue.
+
 ## Central queues {#central-queues}
 
 Jobs dispatched from the central context will remain central. However, it's recommended not to mix queue **connections** for central & tenant jobs due to potential leftover global state, e.g. central jobs thinking they're in the previous tenant's context.


### PR DESCRIPTION
This documents the error resolution for users utilizing a different redis_client and the possibility that they may come across REDIS trying to create a connection when there isn't any connector for that connection