### PR TITLE
No need to change tenancy.central_connection by default

### DIFF
--- a/source/docs/v3/installation.blade.md
+++ b/source/docs/v3/installation.blade.md
@@ -39,4 +39,4 @@ App\Providers\RouteServiceProvider::class,
 App\Providers\TenancyServiceProvider::class, // <-- here
 ```
 
-And finally, name your central connection (in `config/database.php`) `central` — or however else you want, but make sure it's the same name as the `tenancy.central_connection` config.
+And finally, if you want to use a different central database than the one defined by `DB_CONNECTION` in the file `.env`, name your central connection (in `config/database.php`) `central` — or however else you want, but make sure it's the same name as the `tenancy.central_connection` config.


### PR DESCRIPTION
The value of `central_connection` in `config/tenancy.php`:

```php
'central_connection' => env('DB_CONNECTION', 'central'),
```