### PR TITLE
Adds note about TenantAssetController and (separately) the new TrustHost middleware in Laravel 8.0

### DIFF
--- a/source/docs/v3/domains.blade.md
+++ b/source/docs/v3/domains.blade.md
@@ -16,7 +16,9 @@ $tenant->domains()->create([
 ]);
 ```
 
-If you use the subdomain identification middleware, the example above will work for `acme.{any of your central domains}`. If you use the domain identification middleware, use the full hostname like `acme.com`. If you use the combined domain/subdomain identification middleware, `acme` will work as a subdomain and `acme.com` will work as a domain.
+If you use the subdomain identification middleware, the example above will work for `acme.{any of your central domains}`. If you use the domain identification middleware, use the full hostname like `acme.com`. If you use the combined domain/subdomain identification middleware, you should use both `acme` as a subdomain and `acme.com` for the domain.
+
+Note that starting with Laravel 8 and up, Laravel TrustHost middleware is enabled by default (see [laravel/laravel#5477](https://github.com/laravel/laravel/pull/5477)). This blocks Domain-based tenant identification since these requests will be treated as 'untrusted' unless added as a trusted host. You can either comment out this middleware in your App\Http\Kernel.php, or you can adding the custom tenant domains in the App\Http\Middleware\TrustHosts.php `hosts()` method.
 
 To retrieve the current domain model (when using domain identification), you may access the `$currentDomain` public static property on `DomainTenantResolver`.
 

--- a/source/docs/v3/tenancy-bootstrappers.blade.md
+++ b/source/docs/v3/tenancy-bootstrappers.blade.md
@@ -33,9 +33,23 @@ Note that you must use a cache store that supports tagging, e.g. Redis.
 This bootstrapper does the following things:
 
 - Suffixes roots of disks used by the `Storage` facade
-- Suffixes `storage_path()` (useful if you're using the local disk for storing tenant data)
-- Makes `asset()` calls use the TenantAssetController to retrieve tenant-specific data
+- Suffixes `storage_path()` (useful if you're using the local disk for storing tenant files)
+- Makes `asset()` calls use the TenantAssetController to retrieve tenant-specific files
     - Note: For some assets, e.g. images, you may want to use `global_asset()` (if the asset is shared for all tenants). And for JS/CSS assets, you should use `mix()` or again `global_asset()`.
+    - Because the `asset()` helper uses the TenantAssetController to retrieve tenant-specific files. Be aware this requires the tenant to be identified and initialized to function. Accordingly, you should ensure that the tenant identification middleware used is appropriate for your use case (defaults to InitializeTenancyByDomain). For example, if you are only using subdomain identification, you should update the middleware used by the TenantAssetController to the InitializeTenancyBySubdomain middleware. To do this, you can follow the steps outlined in [configuration]({{ $page->link('configuration') }}) to update the public static property which defined the middleware used, e.g. in your TenancyServiceProvider:
+    
+```php
+use Stancl\Tenancy\Controllers\TenantAssetsController;
+use Stancl\Tenancy\Middleware\InitializeTenancyByDomainOrSubdomain;
+
+    // other methods in the TenancyServiceProvider
+
+    public function boot()
+    {
+        // update the middleware used by the asset controller
+        TenantAssetsController::$tenancyMiddleware = InitializeTenancyByDomainOrSubdomain::class;
+    }
+```
 
 This bootstrapper is the most complex one, by far. We will have a — better written — explanation in v3 docs soon, but for now, refer to the 2.x docs for information about filesystem tenancy. [https://tenancyforlaravel.com/docs/v2/filesystem-tenancy/](https://tenancyforlaravel.com/docs/v2/filesystem-tenancy/)
 


### PR DESCRIPTION
Two updates to the docs:

1. Adds a caveat about the TenantAssetController and tenant identification (should be updated based on what tenant identification middleware you're using)
2. Adds a note about the changes in Laravel 8.0 that added TrustHost middleware by default. Closes stancl/tenancy#614 in the main repo. 