### PR TITLE
Update quickstart.blade.md

### DIFF
--- a/source/docs/v3/quickstart.blade.md
+++ b/source/docs/v3/quickstart.blade.md
@@ -189,7 +189,7 @@ App\Tenant::all()->runForEach(function () {
 If you use Laravel 8, the the command is slightly different:
 
 ```php
-App\Models\Tenant::all()->runForEach(function () {
+App\Tenant::all()->runForEach(function () {
     App\Models\User::factory()->create();
 });
 ```


### PR DESCRIPTION
Based on the earlier instruction to create App\Tenant the Laravel 8 command must use App\Tenant instead of App\Models\Tenant. Or, we'll need to adjust the previous instruction to create App\Models\Tenant.