### PR TITLE
Update livewire.blade.md

### DIFF
--- a/source/docs/v3/integrations/livewire.blade.md
+++ b/source/docs/v3/integrations/livewire.blade.md
@@ -15,12 +15,11 @@ Open the `config/livewire.php` file and change this:
 to this:
 
 ```php
-    'middleware_group' => [
-        'web',
-        'universal',
-        InitializeTenancyByDomain::class, // or whatever tenancy middleware you use
-    ],
-
+'middleware_group' => [
+    'web',
+    'universal',
+    InitializeTenancyByDomain::class, // or whatever tenancy middleware you use
+],
 ```
 
 (Don't forget to import the middleware class.)

--- a/source/docs/v3/integrations/livewire.blade.md
+++ b/source/docs/v3/integrations/livewire.blade.md
@@ -15,11 +15,12 @@ Open the `config/livewire.php` file and change this:
 to this:
 
 ```php
-'middleware_group' => [
-    'web',
-    'universal',
-    InitializeTenancyByDomain::class, // or whatever tenancy middleware you use
-],
+    'middleware_group' => [
+        'web',
+        'universal',
+        Stancl\Tenancy\Middleware\InitializeTenancyByDomain::class, // or whatever tenancy middleware you use
+    ],
+
 ```
 
 Now you can use Livewire both in the central app and the tenant app.

--- a/source/docs/v3/integrations/livewire.blade.md
+++ b/source/docs/v3/integrations/livewire.blade.md
@@ -18,10 +18,12 @@ to this:
     'middleware_group' => [
         'web',
         'universal',
-        Stancl\Tenancy\Middleware\InitializeTenancyByDomain::class, // or whatever tenancy middleware you use
+        InitializeTenancyByDomain::class, // or whatever tenancy middleware you use
     ],
 
 ```
+
+(Don't forget to import the middleware class.)
 
 Now you can use Livewire both in the central app and the tenant app.
 


### PR DESCRIPTION
Unless aliased, when going thru the dox on setting up Livewire using the previous code will fail with an error: Target class "[InitializeTenancyByDomain]" does not exist.

Changing it to the full namespace works fine.