### PR TITLE
Fix wrongly formatted code block

### DIFF
--- a/source/docs/v3/integrations/nova.blade.md
+++ b/source/docs/v3/integrations/nova.blade.md
@@ -24,6 +24,7 @@ To use Nova inside of the tenant part of your application, do the following:
 
 - Prevent Nova from adding its migrations to your central migrations by adding `Nova::ignoreMigrations()` to `NovaServiceProvider::boot()` (Don't do this if you want to use Nova **[both in the central & tenant parts]({{ $page->link('features/universal-routes') }})** of the app.)
 - Add the tenancy middleware to your `nova.middleware` config. Example:
+
     ```php
     'middleware' => [
         // You can make this simpler by creating a tenancy route group


### PR DESCRIPTION
Based on other code examples in this file, I guess jumping a line might fix this display issue : 

![Capture d’écran 2021-08-02 à 16 56 05](https://user-images.githubusercontent.com/5576482/127881649-6df13cbb-a6f3-46d2-a4d0-270629d88d04.png)
