### PR TITLE
Add info on automatic cache invalidation

### DIFF
--- a/source/docs/v3/cached-lookup.blade.md
+++ b/source/docs/v3/cached-lookup.blade.md
@@ -31,3 +31,7 @@ DomainTenantResolver::$cacheTTL = 3600;
 // null resolves to the default cache store
 DomainTenantResolver::$cacheStore = 'redis';
 ```
+
+## Cache invalidation
+
+Updating and saving a Tenant model's attributes will cause the cached entry for this model to be invalidated when `DomainTenantResolver::$shouldCache` is set to `true`.


### PR DESCRIPTION
I spent quite some time to find out how to manually invalidate the cache, when during testing I found out this is already handled in the base Tenant model. I know, I should have tried first... But adding this small paragraph might help others.