### PR TITLE
Improve Orchid integration docs page

### DIFF
--- a/source/docs/v3/integrations/orchid.blade.md
+++ b/source/docs/v3/integrations/orchid.blade.md
@@ -6,39 +6,34 @@ section: content
 
 # Laravel Orchid {#laravel-orchid}
 
-The instruction is written for a newly installed Orchid platform, it is proposed to use the platform as a central application and the tenant app.
+First, set up tenancy following the [quickstart guide](/docs/v3/quickstart), and install [Laravel Orchid](https://orchid.software/en/docs/installation/).
 
-## Both in the central app and the tenant app
+To use Orchid both in the central & tenant apps:
 
-Laravel Orchid has already been installed according to the [documentation Orchid](https://orchid.software/en/docs/installation/). All the steps have also been completed [Quickstart Tutorial](/docs/v3/quickstart).
+– Copy the user and Orchid migrations to `migrations\tenant`
 
-- To use Orchid both in the central & tenant parts you need to enable [Universal Routes]({{ $page->link('features/universal-routes') }}).
-- Add the tenancy middleware to your `config\platform.php`
+- Enable [universal routes]({{ $page->link('features/universal-routes') }})
+
+- Add your tenant identification middleware to `config\platform.php` (feel free to use a different identification middleware):
 
     ```php
     'middleware' => [
-        'public'  => ['web', 'universal', \Stancl\Tenancy\Middleware\InitializeTenancyByDomain::class],
-        'private' => ['web', 'platform', 'universal', \Stancl\Tenancy\Middleware\InitializeTenancyByDomain::class],
+        'public'  => ['web', 'universal', InitializeTenancyByDomain::class], // Don't forget to import the middleware
+        'private' => ['web', 'platform', 'universal', InitializeTenancyByDomain::class],
     ],
     ```
 
-- Add a route to `routes\platform.php`
+- Add a route to `routes\platform.php`:
 
     ```php
     Route::screen('/', PlatformScreen::class)
-    ->name('platform.index')
-    ->breadcrumbs(function (Trail $trail) {
-        return $trail->push(__('Home'), route('platform.index'));
-    });
+        ->name('platform.index')
+        ->breadcrumbs(function (Trail $trail) {
+            return $trail->push(__('Home'), route('platform.index'));
+        });
     ```
 
-- In the file `app\Providers\RouteServiceProvider.php`, if necessary, change the path to the "home" route for your central application. By default for Orchid it will be `'admin/main'`
-
-    ```php
-    public const HOME = 'admin/main';
-    ```
-
-- Tenant Routes `routes\tenant.php`
+- Add 'platform' middleware to your tenant routes (`routes\tenant.php`):
 
     ```php
     Route::middleware([
@@ -46,9 +41,5 @@ Laravel Orchid has already been installed according to the [documentation Orchid
         'platform',
         InitializeTenancyByDomain::class,
         PreventAccessFromCentralDomains::class,
-    ])->prefix(Orchid\Platform\Dashboard::prefix('/'))->group(function () {
-        Route::get('/', function () {
-            return 'This is your multi-tenant application. The id of the current tenant is ' . tenant('id');
-        });
-    });
+    ]);
     ```

--- a/source/docs/v3/integrations/orchid.blade.md
+++ b/source/docs/v3/integrations/orchid.blade.md
@@ -6,7 +6,7 @@ section: content
 
 # Laravel Orchid {#laravel-orchid}
 
-First, set up tenancy following the [quickstart guide](/docs/v3/quickstart), and install [Laravel Orchid](https://orchid.software/en/docs/installation/).
+First, set up tenancy following the [quickstart guide]({{ $page->link('quickstart') }}), and install [Laravel Orchid](https://orchid.software/en/docs/installation/).
 
 To use Orchid both in the central and the tenant app:
 

--- a/source/docs/v3/integrations/orchid.blade.md
+++ b/source/docs/v3/integrations/orchid.blade.md
@@ -43,3 +43,5 @@ To use Orchid both in the central and the tenant app:
         PreventAccessFromCentralDomains::class,
     ]);
     ```
+
+- If listing users in the admin panel throws an exception, change line 55 in the UserListLayout class to `return $user->updated_at?->toDateTimeString()` (add null-safe operator)

--- a/source/docs/v3/integrations/orchid.blade.md
+++ b/source/docs/v3/integrations/orchid.blade.md
@@ -8,7 +8,7 @@ section: content
 
 First, set up tenancy following the [quickstart guide](/docs/v3/quickstart), and install [Laravel Orchid](https://orchid.software/en/docs/installation/).
 
-To use Orchid both in the central & tenant apps:
+To use Orchid both in the central and the tenant app:
 
 – Copy the user and Orchid migrations to `migrations\tenant`
 


### PR DESCRIPTION
Rewrote the docs. Removed some bits because they seemed extra (changing `HOME` or prefixing the tenant routes) and added some points because they were missing (copying the migrations, mentioning that the identification middleware doesn't have to be the same as used in the docs examples).

EDIT: seems like Orchid redirects the user to RouteServiceProvider's `HOME` after you log in as admin, ideally, it would redirect the user to the admin panel without the need to change RouteServiceProvider's `HOME`.