### PR TITLE
Update integration for laravel nova 4

### DIFF
--- a/source/docs/v3/integrations/nova.blade.md
+++ b/source/docs/v3/integrations/nova.blade.md
@@ -51,13 +51,13 @@ To use Nova inside of the tenant part of your application, do the following:
         // You can make this simpler by creating a tenancy route group
         InitializeTenancyByDomain::class,
         PreventAccessFromCentralDomains::class,
-        'web',
+        'nova',
     ])
     ->withPasswordResetRoutes([
         // You can make this simpler by creating a tenancy route group
         InitializeTenancyByDomain::class,
         PreventAccessFromCentralDomains::class,
-        'web',
+        'nova',
     ])
     ```
 - Set the `domain` in Nova config to `null`


### PR DESCRIPTION
The previous configuration throws an error when setting up the middleware with 'web', you have to use 'nova' with nova v4.