### PR TITLE
Improve `tenants:run` documentation (issue #120)

### DIFF
--- a/source/docs/v3/console-commands.blade.md
+++ b/source/docs/v3/console-commands.blade.md
@@ -50,6 +50,16 @@ If your command's signature were `email:send {--queue} {--subject=} {body}`, yo
 php artisan tenants:run email:send --tenants=8075a580-1cb8-11e9-8822-49c5d8f8ff23 --option="queue=1" --option="subject=New Feature" --argument="body=We have launched a new feature. ..."
 ```
 
+or using `Artisan::call()`:
+
+```php
+Artisan::call('tenants:run', [
+    'commandname' => 'email:send', // String
+    '--tenants' => ['8075a580-1cb8-11e9-8822-49c5d8f8ff23'] // Array
+    '--option' => ['queue=1', 'subject=New Feature'] // Array
+    '--argument' => ['body=We have launched a new feature.'] // Array
+])
+```
 ## **Tenant list** {#tenant-list}
 
 ```


### PR DESCRIPTION
Calling the Run command using `Artisan::call()` is not documented (https://github.com/stancl/tenancy-docs/issues/120). This PR adds an example of calling the command using `Artisan::call()` with the same arguments and options as the documented example of running the command using CLI.

@stancl, each argument/option has a comment saying which type should be used. Maybe that isn't needed because the types are apparent from the example.