### PR TITLE
Add note about Horizon being used in the central app

### DIFF
--- a/source/docs/v3/integrations/horizon.blade.md
+++ b/source/docs/v3/integrations/horizon.blade.md
@@ -5,12 +5,13 @@ section: content
 ---
 
 # Laravel Horizon {#laravel-horizon}
+> Note: **Horizon is used in the central app**. You can separate the jobs by [tagging them with tenant IDs](#tags).
 
 Make sure your [queues]({{ $page->link('queues') }}) are configured correctly before using this.
 
 ## Tags {#tags}
 
-You may add the current tenant's id to your job tags by defining a `tags` method on the class:
+You may add the current tenant's ID to your job tags by defining a `tags` method on the class:
 
 ```php
 /**

--- a/source/docs/v3/integrations/horizon.blade.md
+++ b/source/docs/v3/integrations/horizon.blade.md
@@ -5,7 +5,7 @@ section: content
 ---
 
 # Laravel Horizon {#laravel-horizon}
-> Note: **Horizon is used in the central app**. You can separate the jobs by [tagging them with tenant IDs](#tags).
+> Note: **Horizon is only accessible on the central domain**. You can separate the jobs by [tagging them with tenant IDs](#tags).
 
 Make sure your [queues]({{ $page->link('queues') }}) are configured correctly before using this.
 


### PR DESCRIPTION
This PR adds a note to the Horizon integration page (https://github.com/stancl/tenancy-docs/issues/75). Also changed 'id' to 'ID'.