### PR TITLE
Add integration guide for Laravel Scout

### DIFF
--- a/navigation.php
+++ b/navigation.php
@@ -204,6 +204,7 @@ return [
                         'Passport' => 'integrations/passport',
                         'Nova' => 'integrations/nova',
                         'Telescope' => 'integrations/telescope',
+                        'Scout' => 'integrations/scout',
                         'Livewire' => 'integrations/livewire',
                         'Orchid' => 'integrations/orchid',
                     ],

--- a/source/docs/v3/integrations/scout.blade.md
+++ b/source/docs/v3/integrations/scout.blade.md
@@ -1,0 +1,18 @@
+---
+title: Laravel Scout integration
+extends: _layouts.documentation
+section: content
+---
+
+# Laravel Scout {#laravel-scout}
+After [installing Scout](https://laravel.com/docs/9.x/scout#installation), make sure the models of all tenants aren't being imported in the same index by prefixing the model indices with the current tenant's key. You can achieve that by adding a listener with this code to the TenancyInitialized event in your TenancyServiceProvider:
+
+```php
+config(['scout.prefix' => tenant()->getTenantKey()]);
+```
+
+After that, you can import your existing records for each tenant using the `tenants:run` command:
+
+```
+php artisan tenants:run scout:import --argument="model=App\Models\YourSearchableModel"
+```


### PR DESCRIPTION
In response to https://github.com/stancl/tenancy-docs/issues/72, I'm adding a short integration guide for Laravel Scout.

<img width="688" alt="image" src="https://user-images.githubusercontent.com/34375937/187208924-f41aad68-ab6c-4951-8c9c-2e51828ab87b.png">
