### PR TITLE
Add Sanctum integration guide

### DIFF
--- a/navigation.php
+++ b/navigation.php
@@ -206,6 +206,7 @@ return [
                         'Telescope' => 'integrations/telescope',
                         'Livewire' => 'integrations/livewire',
                         'Orchid' => 'integrations/orchid',
+                        'Sanctum' => 'integrations/sanctum',
                     ],
                 ],
                 'Console commands' => 'console-commands',

--- a/source/docs/v3/integrating.blade.md
+++ b/source/docs/v3/integrating.blade.md
@@ -15,3 +15,4 @@ If you're using the [automatic mode]({{ $page->link('automatic-mode') }}) & [mul
 - [Laravel Nova]({{ $page->link('integrations/nova') }})
 - [Laravel Telescope]({{ $page->link('integrations/telescope') }})
 - [Livewire]({{ $page->link('integrations/livewire') }})
+- [Laravel Sanctum]({{ $page->link('integrations/sanctum') }})

--- a/source/docs/v3/integrations/sanctum.blade.md
+++ b/source/docs/v3/integrations/sanctum.blade.md
@@ -1,0 +1,22 @@
+---
+title: Laravel Sanctum integration
+extends: _layouts.documentation
+section: content
+---
+
+# Laravel Sanctum {#sanctum}
+
+> Note that the `sanctum` auth guard can't be used with [user impersonation]({{ $page->link('features/user-impersonation') }}) because user impersonation supports stateful guards only.
+
+If you need to use the `csrf-cookie` route that Sanctum provides, you have to set up [universal routes]({{ $page->link('features/universal-routes') }}) in your app. Then, add `'routes' => false` to the `sanctum.php` config.
+
+Finally, add the following code to `routes/tenant.php` (use tenancy initialization middleware of your choice):
+
+```php
+Route::group(['prefix' => config('sanctum.prefix', 'sanctum')], static function () {
+    Route::get('/csrf-cookie',[\Laravel\Sanctum\Http\Controllers\CsrfCookieController::class, 'show'])
+        // Use tenancy initialization middleware of your choice
+        ->middleware(['universal', 'web', \Stancl\Tenancy\Middleware\InitializeTenancyByDomain::class])
+        ->name('sanctum.csrf-cookie');
+});
+```


### PR DESCRIPTION
This adds instructions to make the `csrf-cookie` Sanctum route work with Tenancy (https://github.com/archtechx/tenancy/issues/929), and a note about user impersonation.