### PR TITLE
Add disclaimer about the Passport version (10.x)

### DIFF
--- a/source/docs/v3/integrations/passport.blade.md
+++ b/source/docs/v3/integrations/passport.blade.md
@@ -6,7 +6,7 @@ section: content
 
 # Laravel Passport {#laravel-passport}
 
-> **Disclaimer:** This guide was written for Laravel Passport 10.x
+> **Note:** This guide is written for Laravel Passport 10.x
 
 > **Tip:** If you just want to write an SPA application but don't need an API for some other use (e.g., a mobile app), you can avoid a lot of the complexity of writing SPAs by using [Inertia.js](https://inertiajs.com/).
 

--- a/source/docs/v3/integrations/passport.blade.md
+++ b/source/docs/v3/integrations/passport.blade.md
@@ -6,6 +6,8 @@ section: content
 
 # Laravel Passport {#laravel-passport}
 
+> **Disclaimer:** This guide was written for Laravel Passport 10.x
+
 > **Tip:** If you just want to write an SPA application but don't need an API for some other use (e.g., a mobile app), you can avoid a lot of the complexity of writing SPAs by using [Inertia.js](https://inertiajs.com/).
 
 > **Another tip:** Using Passport only in the central application doesn't require any additional configuration. You can just install it following [the official Laravel Passport documentation](https://laravel.com/docs/9.x/passport).


### PR DESCRIPTION
The Passport guide was written before the release of Passport `11.x`, and `11.x` has a breaking change. `11.x` is going to be supported soon, but for now, I'm adding a disclaimer saying that the guide was written for `10.x`.