### PR TITLE
Passport integration guide fix

### DIFF
--- a/source/docs/v3/integrations/passport.blade.md
+++ b/source/docs/v3/integrations/passport.blade.md
@@ -47,7 +47,10 @@ To use Passport inside the tenant part of your application, you may do the follo
 
     Route::group([
         'as' => 'passport.',
-        'middleware' => [InitializeTenancyByDomain::class], // Use tenancy initialization middleware of your choice
+        'middleware' => [
+            InitializeTenancyByDomain::class, // Use tenancy initialization middleware of your choice
+            PreventAccessFromCentralDomains::class,
+        ],
         'prefix' => config('passport.path', 'oauth'),
         'namespace' => 'Laravel\Passport\Http\Controllers',
     ], function () {

--- a/source/docs/v3/integrations/passport.blade.md
+++ b/source/docs/v3/integrations/passport.blade.md
@@ -17,6 +17,7 @@ section: content
 To use Passport inside the tenant part of your application, you may do the following.
 
 1. Publish the Passport migrations by running `php artisan vendor:publish --tag=passport-migrations` and move them to your tenant migration directory (`database/migrations/tenant/`).
+
 2. Publish the Passport config by running `php artisan vendor:publish --tag=passport-config`. Then, make Passport use the default database connection by setting the storage database connection to `null`. `passport:keys` puts the keys in the `storage/` directory by default – you can change that by setting the key path.
     ```php
     return [
@@ -66,9 +67,13 @@ To use Passport inside the tenant part of your application, you may do the follo
 To use Passport in both the tenant and the central application:
 
 1. Follow [the steps for using Passport in the tenant appliction](#using-passport-in-the-tenant-application-only).
+
 2. Copy the Passport migrations to the central application, so that the Passport migrations are in both the central and the tenant application.
+
 3. Remove `Passport::ignoreMigrations()` from the `register` method in your `AuthServiceProvider` (if it is there).
-4. In your `AuthServiceProvider`, add the `'universal'` middleware to the Passport routes, and remove the `PreventAccessFromCentralDomains::class` middleware (if it is there). The routes should look like this:
+
+4. In your `AuthServiceProvider`'s `register()` method (where you registered the Passport routes), add the `'universal'` middleware to the Passport routes, and remove the `PreventAccessFromCentralDomains::class` middleware. The related code in your `register()` method should look like this:
+
 ```php
 // Passport 10.x
 Passport::routes(null, ['middleware' => [
@@ -91,6 +96,7 @@ Route::group([
     $this->loadRoutesFrom(__DIR__ . "/../../vendor/laravel/passport/src/../routes/web.php");
 });
 ```
+
 5. Enable [universal routes]({{ $page->link('features/universal-routes') }}) to make Passport routes accessible to both apps.
 
 ## **Passport encryption keys** {#passport-encryption-keys}

--- a/source/docs/v3/integrations/passport.blade.md
+++ b/source/docs/v3/integrations/passport.blade.md
@@ -70,9 +70,9 @@ To use Passport in both the tenant and the central application:
 
 2. Copy the Passport migrations to the central application, so that the Passport migrations are in both the central and the tenant application.
 
-3. Remove `Passport::ignoreMigrations()` from the `register` method in your `AuthServiceProvider` (if it is there).
+3. Remove `Passport::ignoreMigrations()` from the `register()` method in your `AuthServiceProvider` (if it is there).
 
-4. In your `AuthServiceProvider`'s `register()` method (where you registered the Passport routes), add the `'universal'` middleware to the Passport routes, and remove the `PreventAccessFromCentralDomains::class` middleware. The related code in your `register()` method should look like this:
+4. In your `AuthServiceProvider`'s `boot()` method (where you registered the Passport routes), add the `'universal'` middleware to the Passport routes, and remove the `PreventAccessFromCentralDomains::class` middleware. The related code in your `boot()` method should look like this:
 
 ```php
 // Passport 10.x

--- a/source/docs/v3/integrations/passport.blade.md
+++ b/source/docs/v3/integrations/passport.blade.md
@@ -43,7 +43,7 @@ To use Passport inside the tenant part of your application, you may do the follo
 5. If you're using Passport 11.x, disable the automatic Passport route registering and register the routes manually by adding the following code to the `register` method in your `AuthServiceProvider`:
 
 ```php
-    Passport::$registersRoutes = false;
+    Passport::ignoreRoutes();
 
     Route::group([
         'as' => 'passport.',
@@ -74,7 +74,7 @@ Passport::routes(null, ['middleware' => [
 ]]);
 
 // Passport 11.x
-Passport::$registersRoutes = false;
+Passport::ignoreRoutes();
 
 Route::group([
     'as' => 'passport.',

--- a/source/docs/v3/integrations/passport.blade.md
+++ b/source/docs/v3/integrations/passport.blade.md
@@ -30,9 +30,9 @@ To use Passport inside the tenant part of your application, you may do the follo
     ];
     ```
 
-3. Prevent Passport migrations from running in the central application by adding `Passport::ignoreMigrations()` to the `register` method in your `AuthServiceProvider`.
+3. Prevent Passport migrations from running in the central application by adding `Passport::ignoreMigrations()` to the `register()` method in your `AuthServiceProvider`.
 
-4. If you're using Passport 10.x, register the Passport routes in your `AuthServiceProvider` by adding the following code to the provider's `boot` method:
+4. If you're using Passport 10.x, register the Passport routes in your `AuthServiceProvider` by adding the following code to the provider's `boot()` method:
 ```php
     Passport::routes(null, ['middleware' => [
         InitializeTenancyByDomain::class, // Or other identification middleware of your choice
@@ -41,11 +41,9 @@ To use Passport inside the tenant part of your application, you may do the follo
 ```
 
 
-5. If you're using Passport 11.x, disable the automatic Passport route registering and register the routes manually by adding the following code to the `register` method in your `AuthServiceProvider`:
+5. If you're using Passport 11.x, disable the automatic Passport route registering in your `AuthServiceProvider` by adding `Passport::ignoreRoutes();` to the `register()` method. Then, register the Passport routes manually by adding the following code to the `boot()` method:
 
 ```php
-    Passport::ignoreRoutes();
-
     Route::group([
         'as' => 'passport.',
         'middleware' => [
@@ -82,8 +80,6 @@ Passport::routes(null, ['middleware' => [
 ]]);
 
 // Passport 11.x
-Passport::ignoreRoutes();
-
 Route::group([
     'as' => 'passport.',
     'middleware' => [


### PR DESCRIPTION
In response to [the Discord discussion](https://discord.com/channels/976506366502006874/976506736120823909/1052300324137861280), this PR updates the Passport integration guide.

- The 11.x route example is now present
- In the "Using Passport in both the tenant and the central application" section, the first step now instructs to follow the steps for making Passport work with tenant apps
- All `AppServiceProvider` mentions changed to `AuthServiceProvider`