### PR TITLE
Improve Sanctum integration page

### DIFF
--- a/source/docs/v3/integrations/sanctum.blade.md
+++ b/source/docs/v3/integrations/sanctum.blade.md
@@ -27,7 +27,7 @@ Route::group(['prefix' => config('sanctum.prefix', 'sanctum')], static function 
 });
 ```
 
-### Sanctum's csrf-cookie in both the central and the tenant app
+### Sanctum's csrf-cookie route in both the central and the tenant app
 
 To use the `sanctum.csrf-cookie` route in both the central and the tenant apps:
 

--- a/source/docs/v3/integrations/sanctum.blade.md
+++ b/source/docs/v3/integrations/sanctum.blade.md
@@ -6,17 +6,33 @@ section: content
 
 # Laravel Sanctum {#sanctum}
 
-> Note that the `sanctum` auth guard can't be used with [user impersonation]({{ $page->link('features/user-impersonation') }}) because user impersonation supports stateful guards only.
+> Note: The `sanctum` auth guard can't be used with [user impersonation]({{ $page->link('features/user-impersonation') }}) because user impersonation supports stateful guards only.
 
-If you need to use the `csrf-cookie` route that Sanctum provides, you have to set up [universal routes]({{ $page->link('features/universal-routes') }}) in your app. Then, add `'routes' => false` to the `sanctum.php` config.
+### Sanctum's csrf-cookie route in the tenant app
 
-Finally, add the following code to `routes/tenant.php` (use tenancy initialization middleware of your choice):
+To make the `sanctum.csrf-cookie` route work in the tenant app, do the following:
+
+1. Add `'routes' => false` to the `sanctum.php` config
+2. Publish the Sanctum migrations and move them to `migrations/tenant`
+3. Make Sanctum not use its migrations in the central app by adding `Sanctum::ignoreMigrations()` to the `register()` method in your `AuthServiceProvider`
+4. Add the following code to `routes/tenant.php` to override the original `sanctum.csrf-cookie` route:
 
 ```php
 Route::group(['prefix' => config('sanctum.prefix', 'sanctum')], static function () {
-    Route::get('/csrf-cookie',[\Laravel\Sanctum\Http\Controllers\CsrfCookieController::class, 'show'])
-        // Use tenancy initialization middleware of your choice
-        ->middleware(['universal', 'web', \Stancl\Tenancy\Middleware\InitializeTenancyByDomain::class])
-        ->name('sanctum.csrf-cookie');
+    Route::get('/csrf-cookie', [CsrfCookieController::class, 'show'])
+        ->middleware([
+            'web',
+            InitializeTenancyByDomain::class // Use tenancy initialization middleware of your choice
+        ])->name('sanctum.csrf-cookie');
 });
 ```
+
+### Sanctum's csrf-cookie in both the central and the tenant app
+
+To use the `sanctum.csrf-cookie` route in both the central and the tenant apps:
+
+1. Follow the steps in the previous section ("Sanctum's csrf-cookie route in the tenant app")
+2. Set up [universal routes]({{ $page->link('features/universal-routes') }})
+3. Remove `Sanctum::ignoreMigrations()` from your `AuthServiceProvider`'s `register()` method
+4. Remove `'routes' => false` from the `sanctum.php` config
+5. Add the `'universal'` middleware to the `sanctum.csrf-cookie` route in your `routes/tenant.php`

--- a/source/docs/v3/integrations/sanctum.blade.md
+++ b/source/docs/v3/integrations/sanctum.blade.md
@@ -8,7 +8,9 @@ section: content
 
 > Note: The `sanctum` auth guard can't be used with [user impersonation]({{ $page->link('features/user-impersonation') }}) because user impersonation supports stateful guards only.
 
-### Sanctum's csrf-cookie route in the tenant app
+Laravel Sanctum works with Tenancy out of the box, with the exception of the `sanctum.csrf-cookie` route.
+
+### Making the csrf-cookie route work in the tenant app
 
 To make the `sanctum.csrf-cookie` route work in the tenant app, do the following:
 
@@ -27,7 +29,7 @@ Route::group(['prefix' => config('sanctum.prefix', 'sanctum')], static function 
 });
 ```
 
-### Sanctum's csrf-cookie route in both the central and the tenant app
+### Making the csrf-cookie route work both in the central and the tenant app
 
 To use the `sanctum.csrf-cookie` route in both the central and the tenant apps:
 

--- a/source/docs/v3/integrations/sanctum.blade.md
+++ b/source/docs/v3/integrations/sanctum.blade.md
@@ -8,7 +8,7 @@ section: content
 
 > Note: The `sanctum` auth guard can't be used with [user impersonation]({{ $page->link('features/user-impersonation') }}) because user impersonation supports stateful guards only.
 
-Laravel Sanctum works with Tenancy out of the box, with the exception of the `sanctum.csrf-cookie` route.
+Laravel Sanctum works with Tenancy out of the box, with the exception of the `sanctum.csrf-cookie` route. You can make some small changes to make the route work.
 
 ### Making the csrf-cookie route work in the tenant app
 


### PR DESCRIPTION
Previously, the Sanctum integration guide assumed that the user wanted to make the csrf-cookie route work in both the tenant and the central app. This PR updates the guide so that it gives the user instructions on how to make it work in the tenant app itself, or in both the tenant and the central app.

Related Discord discussion: https://discord.com/channels/976506366502006874/976506736120823909/1052528376323248128