### PR TITLE
Cache invalidation solution + note

### DIFF
--- a/source/docs/v3/cached-lookup.blade.md
+++ b/source/docs/v3/cached-lookup.blade.md
@@ -35,3 +35,10 @@ DomainTenantResolver::$cacheStore = 'redis';
 ## Cache invalidation
 
 Updating and saving a Tenant model's attributes will cause the cached entry for this model to be invalidated when `DomainTenantResolver::$shouldCache` is set to `true`.
+
+You may invalidate the cache by calling :
+```php
+app(\Stancl\Tenancy\Resolvers\DomainTenantResolver::class)->invalidateCache($tenant);
+```
+
+> Note: When using the domain identification, the key of the cache contains the name of the domain. Make sure to invalidate the cache before making any changes if you intend to update the domain name.


### PR DESCRIPTION
Because I started to use the cache lookup recently, I've had some issues with the cache invalidation.

I though of sharing the solutions in the documentation:
- Added a solution how to invalidate the cache.

- Added a note/warning to invalidate the cache before  if you intend to update the domain name. Otherwise the invalidate cache will not work as the key will have changed because of the new domain name.