### PR TITLE
fixes confusing typo on Tenants page

### DIFF
--- a/source/docs/v3/tenants.blade.md
+++ b/source/docs/v3/tenants.blade.md
@@ -12,7 +12,7 @@ The package comes with a base `Tenant` model that's ready for common things, tho
 
 The base model has the following features on top of the ones that are necessary by the interface:
 
-- Forced central connection (lets you interact with Central models even in Tenant contexts)
+- Forced central connection (lets you interact with `Tenant` models even in the tenant context)
 - Data column trait — lets you store arbitrary keys. Attributes that don't exist as columns on your `tenants` table go to the `data` column as serialized JSON.
 - Id generation trait — when you don't supply an ID, a random uuid will be generated. An alternative to this would be using AUTOINCREMENT columns. If you wish to use numerical ids, change the `create_tenants_table` migration to use `bigIncrements()` or some such column type, and set `tenancy.id_generator` config to null. That will disable the ID generation altogether, falling back to the database's autoincrement mechanism.
 

--- a/source/docs/v3/tenants.blade.md
+++ b/source/docs/v3/tenants.blade.md
@@ -12,7 +12,7 @@ The package comes with a base `Tenant` model that's ready for common things, tho
 
 The base model has the following features on top of the ones that are necessary by the interface:
 
-- Forced central connection (lets you interact with Tenant models even in tenant contexts)
+- Forced central connection (lets you interact with Central models even in Tenant contexts)
 - Data column trait — lets you store arbitrary keys. Attributes that don't exist as columns on your `tenants` table go to the `data` column as serialized JSON.
 - Id generation trait — when you don't supply an ID, a random uuid will be generated. An alternative to this would be using AUTOINCREMENT columns. If you wish to use numerical ids, change the `create_tenants_table` migration to use `bigIncrements()` or some such column type, and set `tenancy.id_generator` config to null. That will disable the ID generation altogether, falling back to the database's autoincrement mechanism.
 


### PR DESCRIPTION
Don't know what exactly this line is referring to (eg, `CentralConnection` concern, the `$tenant->run...` function, or something else)...but I'm 95% sure this was a typo in one direction or the other. Hope that helps!