### PR TITLE
Update nova.blade.md

### DIFF
--- a/source/docs/v3/integrations/nova.blade.md
+++ b/source/docs/v3/integrations/nova.blade.md
@@ -51,13 +51,13 @@ To use Nova inside of the tenant part of your application, do the following:
         // You can make this simpler by creating a tenancy route group
         InitializeTenancyByDomain::class,
         PreventAccessFromCentralDomains::class,
-        'nova',
+        'web',
     ])
     ->withPasswordResetRoutes([
         // You can make this simpler by creating a tenancy route group
         InitializeTenancyByDomain::class,
         PreventAccessFromCentralDomains::class,
-        'nova',
+        'web',
     ])
     ```
 - Set the `domain` in Nova config to `null`


### PR DESCRIPTION
Laravel Nova middleware called `nova` use `Laravel\Nova\Http\Middleware::class` which cause infinite redirects. Default `withAuthenticationRoutes` and `withPasswordResetRoutes` route group is `web` so it doesn't make sens to add `nova` middleware group there.