### PR TITLE
Correct Passport integration guide

### DIFF
--- a/source/docs/v3/integrations/passport.blade.md
+++ b/source/docs/v3/integrations/passport.blade.md
@@ -18,10 +18,10 @@ To use Passport inside the tenant part of your application, you may do the follo
 
 1. Publish the Passport migrations by running `php artisan vendor:publish --tag=passport-migrations` and move them to your tenant migration directory (`database/migrations/tenant/`).
 
-2. Publish the Passport config by running `php artisan vendor:publish --tag=passport-config`. Then, make Passport use the default database connection by setting the storage database connection to `null`. `passport:keys` puts the keys in the `storage/` directory by default – you can change that by setting the key path.
+2. Publish the Passport config by running `php artisan vendor:publish --tag=passport-config`. If you're using Passport 10.x, make Passport use the default database connection by setting the storage database connection to `null`. The `passport:keys` command puts the keys in the `storage/` directory by default – you can change that by setting the key path in the config.
     ```php
     return [
-        'storage' => [
+        'storage' => [ // Needed only when using Passport 10.x
             'database' => [
                 'connection' => null,
             ],


### PR DESCRIPTION
Mention that making Passport use the default DB connection is only necessary with Passport 10.x

https://discord.com/channels/976506366502006874/976506701782069308/1074730494928891994