### PR TITLE
Add grant option to sail user

### DIFF
--- a/source/docs/v3/integrations/sail.blade.md
+++ b/source/docs/v3/integrations/sail.blade.md
@@ -13,7 +13,7 @@ section: content
 The default Sail user can only perform the create, read, update and delete operations in the central database. To allow the user to perform these operations in the tenant databases too, log in to Sail's MySQL shell as the root user (`docker-compose exec mysql bash`, then `mysql -u root -p` – by default, the password is determined by the `DB_PASSWORD` variable in your `.env`) and grant the Sail user access to all databases by running the following statements:
 
 ```sh
-GRANT ALL PRIVILEGES on *.* to 'sail'@'%';
+GRANT ALL PRIVILEGES ON *.* TO 'sail'@'%' WITH GRANT OPTION;
 FLUSH PRIVILEGES;
 ```
 


### PR DESCRIPTION
When you execute `GRANT ALL PRIVILEGES ON *.* TO 'sail'@'%';`, it grants the 'sail' user extensive permissions, including the ability to manage databases and create users.

However, this does not enable the 'sail' user to delegate database access permissions to another user, leading to permission errors while using package as newly created user will not have access to newly created database.

For this, `WITH GRANT OPTION` should be added to sail user.