### PR TITLE
Real Time Facades: Deleting framework directories for tenants solution

### DIFF
--- a/source/docs/v3/realtime-facades.blade.md
+++ b/source/docs/v3/realtime-facades.blade.md
@@ -63,3 +63,40 @@ class CreateFrameworkDirectoriesForTenant
     }
 }
 ```
+
+## Deleting framework directories for tenants {#deleting-framework-directories-for-tenants}
+
+If you used the previous solution and created the framework directories for a tenant, then you may be interested in
+deleting the framework directories once the tenant has been destroyed. Similarly, you will have to create a new `Job` that
+will remove any framework files created previously.
+
+Similarly, create a new `Job` like the one below, and add the `Job` to the `TenantDeleted` job pipeline
+
+```php
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Facades\File;
+use Stancl\Tenancy\Contracts\Tenant;
+
+class DeleteFrameworkDirectoriesForTenant implements ShouldQueue
+{
+    protected Tenant $tenant;
+
+    public function __construct(Tenant $tenant)
+    {
+        $this->tenant = $tenant;
+    }
+
+    public function handle(): void
+    {
+        $this->tenant->run(function ($tenant) {
+            $storage_path = storage_path();
+
+            File::deleteDirectory($storage_path);
+        });
+    }
+}
+```


### PR DESCRIPTION
In Real Time Facades section, there is already the solution given for Adding the framework directories

However. Once the Tenant is deleted, one should also make sure that the framework directories are deleted. Otherwise you will stay with leftover files

Hence, In this PR I added a small section on how one can delete the framework directories when the Tenant is deleted. 

PS: I think this could be useful not only in the docs but perhaps as a complete solution that can be toggled on/off from the config file. Let me know if such solution would interest you, perhaps I can open a PR on the main repository