### PR TITLE
:memo: Responsive Image URLs in TenantAwareUrlGenerator to be Tenant-Aware

### DIFF
--- a/source/docs/v3/integrations/spatie.blade.md
+++ b/source/docs/v3/integrations/spatie.blade.md
@@ -72,10 +72,11 @@ The reason for this is that spatie/laravel-permission caches permissions & roles
 
 ## **laravel-medialibrary** {#laravel-medialibrary}
 
-To generate the correct media URLs for tenants, create a custom URL generator class extending `Spatie\MediaLibrary\Support\UrlGenerator\DefaultUrlGenerator` and override the `getUrl()` method:
+To generate the correct media URLs for tenants, create a custom URL generator class extending `Spatie\MediaLibrary\Support\UrlGenerator\DefaultUrlGenerator` and override the `getUrl()` method and the `getResponsiveImagesDirectoryUrl` method that is used for generating URLs of responsive images.
 
 ```php
 use Spatie\MediaLibrary\Support\UrlGenerator\DefaultUrlGenerator;
+use Illuminate\Support\Str;
 
 class TenantAwareUrlGenerator extends DefaultUrlGenerator
 {
@@ -86,6 +87,13 @@ class TenantAwareUrlGenerator extends DefaultUrlGenerator
         $url = $this->versionUrl($url);
 
         return $url;
+    }
+
+    public function getResponsiveImagesDirectoryUrl(): string
+    {
+        $path = $this->pathGenerator->getPathForResponsiveImages($this->media);
+
+        return Str::finish(tenant_asset($path), '/');
     }
 }
 ```


### PR DESCRIPTION
This pull request addresses an issue with the `TenantAwareUrlGenerator` where the URLs in the `srcset` attribute of responsive images were not tenant-aware, even though the `src` URL was correctly tenant-aware.

### Problem
When fetching the HTML for a media image using the following code:
```php
$item->getFirstMedia('myMediaCollection')?->toHtml()
```
The generated `<img>` tag had the correct tenant-aware `src` attribute, but the `srcset` attribute URLs were not tenant-aware.

### Cause
The issue was traced to the `getResponsiveImagesDirectoryUrl` method in the `DefaultUrlGenerator`, which was responsible for generating the URLs for responsive images.

### Solution
To fix this, I have overridden the `getResponsiveImagesDirectoryUrl` method in the `TenantAwareUrlGenerator` to ensure that the URLs for responsive images are also tenant-aware.

### Changes
- **Added**: `getResponsiveImagesDirectoryUrl` method override in `TenantAwareUrlGenerator` to generate tenant-aware URLs for responsive images.

This change ensures consistency in URL generation for both `src` and `srcset` attributes, preventing potential issues where non-tenant-aware URLs might lead to incorrect media being served.

---

Please review the changes and let me know if you have any concerns. Thank you!