### PR TITLE
Update passport.blade.md Regarding Passport 12 Shared Keys

### DIFF
--- a/source/docs/v3/integrations/passport.blade.md
+++ b/source/docs/v3/integrations/passport.blade.md
@@ -112,6 +112,24 @@ public function run()
 
 Then, seed the database and generate the key pair by running `php artisan passport:keys`.
 
+#### Passport version 12 & shared keys {#passport-12-shared-keys}
+> **Note**: When using **Passport 12+** with **shared** keys, 
+Passport may look for those key files in a **tenant-specific** path, such as 
+`/storage/{tenant}/...`. If you only have **one** shared key pair, you can force 
+Passport to load them from the **central** storage path by placing the following code 
+in your `AppServiceProvider` or `AuthServiceProvider`:
+
+```php
+use Laravel\Passport\Passport;
+
+public function boot()
+{
+    Passport::loadKeysFrom(storage_path());
+    // ...
+}
+```
+This ensures Passport uses storage/oauth-private.key and storage/oauth-public.key for all tenants. If you do not call loadKeysFrom(), Passport might attempt to read from storage/tenant/{tenant}/oauth-private.key and fail if tenant-specific keys do not exist.
+
 ### **Tenant-specific keys** {#tenant-specific-keys}
 > **Note:** The security benefit of doing this is negligible since you're likely already using the same `APP_KEY` for all tenants. This is a relatively complex approach, so before implementing it, make sure you really want it. **Using shared keys instead is strongly recommended.**
 


### PR DESCRIPTION
docs: add note on Passport v12 key path for shared keys in tenant environment

- Added a subsection under “Shared keys” explaining how to use `Passport::loadKeysFrom(storage_path())` to force Passport to load a single key pair from the central storage path for all tenants.
- Helps avoid tenant-specific key path issues in Passport v12.

This update adds a short note in the Shared keys section clarifying that Passport 12 may look for its encryption keys in a tenant-specific directory (/storage/tenant/{tenant}/...). We’ve included instructions on forcing Passport to load keys from a single shared path, ensuring all tenants use the same key files. This avoids potential issues where tenant-scoped folders do not contain their own Passport keys.